### PR TITLE
Add an --env option

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -78,7 +78,9 @@ happy can find it later.
 - ``--env``
 
   (optional) Environment variable overrides, e.g. ``--env KEY=value``. For
-  multiple variables, this option can be passed more than once.
+  multiple variables, this option can be passed more than once. Variable names
+  MUST match one of the names in the ``env`` section of your ``app.json``, or
+  the build will fail with an ``invalid app.json`` message.
 
 - ``--tarball-url``
 

--- a/README.rst
+++ b/README.rst
@@ -75,6 +75,11 @@ happy can find it later.
   logged in through Heroku CLI, i.e. your token is stored in your ``netrc``
   file.
 
+- ``--env``
+
+  (optional) Environment variable overrides, e.g. ``--env KEY=value``. For
+  multiple variables, this option can be passed more than once.
+
 - ``--tarball-url``
 
   (optional) URL of the tarball containing app.json. If this is not given,

--- a/happy/__init__.py
+++ b/happy/__init__.py
@@ -15,13 +15,14 @@ class Happy(object):
         """
         self._api = Heroku(auth_token=auth_token)
 
-    def create(self, tarball_url):
+    def create(self, tarball_url, env=None):
         """Creates a Heroku app-setup build.
 
         :param tarball_url: URL of a tarball containing an ``app.json``.
+        :param env: Dict containing environment variable overrides.
         :returns: A tuple with ``(build_id, app_name)``.
         """
-        data = self._api.create_build(tarball_url=tarball_url)
+        data = self._api.create_build(tarball_url=tarball_url, env=env)
 
         return (data['id'], data['app']['name'])
 

--- a/happy/cli.py
+++ b/happy/cli.py
@@ -52,7 +52,8 @@ def cli():
 @cli.command(name='up')
 @click.option('--tarball-url', help='URL of the tarball containing app.json.')
 @click.option('--auth-token', help='Heroku API auth token.')
-def up(tarball_url, auth_token):
+@click.option('--env', multiple=True, help='Env override, e.g. KEY=value.')
+def up(tarball_url, auth_token, env):
     """Brings up a Heroku app."""
     tarball_url = tarball_url or _infer_tarball_url()
 
@@ -60,11 +61,18 @@ def up(tarball_url, auth_token):
         click.echo('No tarball URL found.')
         sys.exit(1)
 
+    if env:
+        # Split ["KEY=value", ...] into {"KEY": "value", ...}
+        env = {
+            arg.split('=')[0]: arg.split('=')[1]
+            for arg in env
+        }
+
     happy = Happy(auth_token=auth_token)
 
     click.echo('Creating app... ', nl=False)
 
-    build_id, app_name = happy.create(tarball_url=tarball_url)
+    build_id, app_name = happy.create(tarball_url=tarball_url, env=env)
 
     click.echo(app_name)
 

--- a/happy/heroku.py
+++ b/happy/heroku.py
@@ -66,10 +66,11 @@ class Heroku(object):
 
         return response.json()
 
-    def create_build(self, tarball_url):
+    def create_build(self, tarball_url, env=None):
         """Creates an app-setups build. Returns response data as a dict.
 
         :param tarball_url: URL of a tarball containing an ``app.json``.
+        :param env: Dict containing environment variable overrides.
         :returns: Response data as a ``dict``.
         """
         data = {
@@ -77,6 +78,9 @@ class Heroku(object):
                 'url': tarball_url
             }
         }
+
+        if env:
+            data['overrides'] = {'env': env}
 
         return self.api_request('POST', '/app-setups', data=data)
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -96,6 +96,26 @@ def test_up_no_tarball_url(happy, runner):
     assert 'no tarball' in result.output.lower()
 
 
+def test_up_env(happy, runner):
+    """Running up --env should pass environment overrides."""
+    with runner.isolated_filesystem():
+        runner.invoke(cli, [
+            'up',
+            '--env',
+            'FART=test',
+            '--env',
+            'BUTT=wow',
+            '--tarball-url=example.com',
+        ])
+
+    args_, kwargs = happy().create.call_args
+
+    assert kwargs['env'] == {
+        'FART': 'test',
+        'BUTT': 'wow',
+    }
+
+
 def test_up_writes_app_name(happy, runner):
     """Running up should write the app name to .happy."""
     with runner.isolated_filesystem():

--- a/tests/test_happy.py
+++ b/tests/test_happy.py
@@ -39,7 +39,20 @@ def test_create(heroku, happy):
     """Should create an app build on Heroku."""
     happy.create(tarball_url='tarball-url')
 
-    heroku().create_build.assert_called_with(tarball_url='tarball-url')
+    heroku().create_build.assert_called_with(
+        env=None,
+        tarball_url='tarball-url',
+    )
+
+
+def test_create_env(heroku, happy):
+    """Should pass env overrides to Heroku.create_build."""
+    happy.create(tarball_url='tarball-url', env={'TEST': 'env'})
+
+    heroku().create_build.assert_called_with(
+        tarball_url='tarball-url',
+        env={'TEST': 'env'},
+    )
 
 
 def test_create_returns_app_name(heroku, happy):

--- a/tests/test_heroku.py
+++ b/tests/test_heroku.py
@@ -125,6 +125,23 @@ def test_heroku_create_build(api_request):
 
 
 @mock.patch.object(Heroku, 'api_request')
+def test_heroku_create_build_env(api_request):
+    """Heroku.create_build should send a POST to /app-setups."""
+    heroku = Heroku()
+
+    result = heroku.create_build('tarball-url', env={'HELLO': 'world'})
+
+    api_request.assert_called_with(
+        'POST',
+        '/app-setups',
+        data={
+            'source_blob': {'url': 'tarball-url'},
+            'overrides': {'env': {'HELLO': 'world'}},
+        },
+    )
+
+
+@mock.patch.object(Heroku, 'api_request')
 def test_heroku_check_build_status(api_request):
     """Heroku.check_build_status should send a GET to /app-setups/:id."""
     api_request.return_value = {'status': 'pending'}


### PR DESCRIPTION
Adds an `--env` option to `happy up` to pass environment variable overrides. Closes #5.
