### PR TITLE
Add an app name parameter

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -101,7 +101,6 @@ Usage: `happy down [OPTIONS] [APP_NAME]`
 
 Brings down a Heroku app.
 
-
 - ``APP_NAME``
 
   (optional) Name of the Heroku app to delete. If this is not given, the app
@@ -112,6 +111,10 @@ Brings down a Heroku app.
   (optional) Heroku API auth token. If this is not given, happy assumes you're
   logged in through Heroku CLI, i.e. your token is stored in your ``netrc``
   file.
+
+- ``--force``
+
+  (optional) Suppress the delete confirmation prompt. Useful for automation!
 
 Running the tests
 -----------------

--- a/README.rst
+++ b/README.rst
@@ -97,11 +97,15 @@ happy can find it later.
 down
 ~~~~
 
-Usage: `happy down [OPTIONS]`
+Usage: `happy down [OPTIONS] [APP_NAME]`
 
 Brings down a Heroku app.
 
-The app name is read from a file called ``.happy`` in the working directory.
+
+- ``APP_NAME``
+
+  (optional) Name of the Heroku app to delete. If this is not given, the app
+  name is read from a file called ``.happy`` in the working directory.
 
 - ``--auth-token``
 

--- a/README.rst
+++ b/README.rst
@@ -64,10 +64,17 @@ Commands
 up
 ~~
 
+Usage: `happy up [OPTIONS] [APP_NAME]`
+
 Brings up a Heroku app.
 
 The app name is stored in a file called ``.happy`` in the working directory so
 happy can find it later.
+
+- ``APP_NAME``
+
+  (optional) Name of the Heroku app to create. If this is not given, one is
+  chosen for you by the Heroku API.
 
 - ``--auth-token``
 
@@ -89,6 +96,8 @@ happy can find it later.
 
 down
 ~~~~
+
+Usage: `happy down [OPTIONS]`
 
 Brings down a Heroku app.
 

--- a/happy/__init__.py
+++ b/happy/__init__.py
@@ -15,14 +15,19 @@ class Happy(object):
         """
         self._api = Heroku(auth_token=auth_token)
 
-    def create(self, tarball_url, env=None):
+    def create(self, tarball_url, env=None, app_name=None):
         """Creates a Heroku app-setup build.
 
         :param tarball_url: URL of a tarball containing an ``app.json``.
-        :param env: Dict containing environment variable overrides.
+        :param env: (optional) Dict containing environment variable overrides.
+        :param app_name: (optional) Name of the Heroku app to create.
         :returns: A tuple with ``(build_id, app_name)``.
         """
-        data = self._api.create_build(tarball_url=tarball_url, env=env)
+        data = self._api.create_build(
+            tarball_url=tarball_url,
+            env=env,
+            app_name=app_name,
+        )
 
         return (data['id'], data['app']['name'])
 

--- a/happy/cli.py
+++ b/happy/cli.py
@@ -98,9 +98,10 @@ def up(tarball_url, auth_token, env, app_name):
 
 @cli.command(name='down')
 @click.option('--auth-token', help='Heroku API auth token.')
-def down(auth_token):
+@click.argument('app_name', required=False)
+def down(auth_token, app_name):
     """Brings down a Heroku app."""
-    app_name = _read_app_name()
+    app_name = app_name or _read_app_name()
 
     if not app_name:
         click.echo('No app is running.')

--- a/happy/cli.py
+++ b/happy/cli.py
@@ -58,7 +58,8 @@ def cli():
 @click.option('--tarball-url', help='URL of the tarball containing app.json.')
 @click.option('--auth-token', help='Heroku API auth token.')
 @click.option('--env', multiple=True, help='Env override, e.g. KEY=value.')
-def up(tarball_url, auth_token, env):
+@click.argument('app_name', required=False)
+def up(tarball_url, auth_token, env, app_name):
     """Brings up a Heroku app."""
     tarball_url = tarball_url or _infer_tarball_url()
 
@@ -77,7 +78,11 @@ def up(tarball_url, auth_token, env):
 
     click.echo('Creating app... ', nl=False)
 
-    build_id, app_name = happy.create(tarball_url=tarball_url, env=env)
+    build_id, app_name = happy.create(
+        tarball_url=tarball_url,
+        env=env,
+        app_name=app_name,
+    )
 
     click.echo(app_name)
 

--- a/happy/cli.py
+++ b/happy/cli.py
@@ -21,7 +21,12 @@ def _infer_tarball_url():
     except IOError:
         return None
 
-    return app_json.get('repository') + '/tarball/master/'
+    repository = app_json.get('repository')
+
+    if not repository:
+        return None
+    else:
+        return app_json.get('repository') + '/tarball/master/'
 
 
 def _write_app_name(app_name):

--- a/happy/heroku.py
+++ b/happy/heroku.py
@@ -66,11 +66,12 @@ class Heroku(object):
 
         return response.json()
 
-    def create_build(self, tarball_url, env=None):
+    def create_build(self, tarball_url, env=None, app_name=None):
         """Creates an app-setups build. Returns response data as a dict.
 
         :param tarball_url: URL of a tarball containing an ``app.json``.
         :param env: Dict containing environment variable overrides.
+        :param app_name: Name of the Heroku app to create.
         :returns: Response data as a ``dict``.
         """
         data = {
@@ -81,6 +82,9 @@ class Heroku(object):
 
         if env:
             data['overrides'] = {'env': env}
+
+        if app_name:
+            data['app'] = {'name': app_name}
 
         return self.api_request('POST', '/app-setups', data=data)
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -67,6 +67,16 @@ def test_up(runner, happy):
 
 
 @isolated
+def test_up_app_name(runner, happy):
+    """Running up should pass the first param as the app name."""
+    runner.invoke(cli, ['up', 'app-name-123'])
+
+    args_, kwargs = happy().create.call_args
+
+    assert kwargs['app_name'] == 'app-name-123'
+
+
+@isolated
 def test_up_auth_token(runner, happy):
     """Running up should pass the --auth-token option to Happy."""
     runner.invoke(cli, [

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,6 +1,7 @@
 """
 Tests for the cli commands.
 """
+import os
 import subprocess
 
 import decorator
@@ -114,6 +115,17 @@ def test_up_no_tarball_url(runner, happy):
     """Running up should fail if it can't infer the tarball URL."""
     with open('app.json', 'w') as f:
         f.write('{"description": "No repository????"}')
+
+    result = runner.invoke(cli, ['up'])
+
+    assert result.exit_code == 1
+    assert 'no tarball' in result.output.lower()
+
+
+@isolated
+def test_up_no_tarball_url_or_app_json(runner, happy):
+    """Running up should fail if app.json and --tarball-url are missing."""
+    os.unlink('app.json')
 
     result = runner.invoke(cli, ['up'])
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -2,8 +2,8 @@
 Tests for the cli commands.
 """
 import subprocess
-from functools import wraps
 
+import decorator
 import mock
 import pytest
 from click.testing import CliRunner
@@ -39,15 +39,14 @@ def isolated(func):
 
     This also stubs out an app.json for convenience.
     """
-    @wraps(func)
-    def wrapped(runner, *args, **kwargs):
+    def wrapped(func, runner, *args, **kwargs):
         with runner.isolated_filesystem():
             with open('app.json', 'w') as f:
                 f.write('{"repository": "https://github.com/butt/man"}')
 
             return func(runner, *args, **kwargs)
 
-    return wrapped
+    return decorator.decorator(wrapped, func)
 
 
 def test_help(runner):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -2,6 +2,7 @@
 Tests for the cli commands.
 """
 import subprocess
+from functools import wraps
 
 import mock
 import pytest
@@ -33,6 +34,16 @@ def runner():
     return CliRunner()
 
 
+def isolated(func):
+    """Runs a method in an isolated filesystem."""
+    @wraps(func)
+    def wrapped(runner, *args, **kwargs):
+        with runner.isolated_filesystem():
+            return func(runner, *args, **kwargs)
+
+    return wrapped
+
+
 def test_help(runner):
     """Running happy should print the help."""
     result = runner.invoke(cli)
@@ -41,45 +52,45 @@ def test_help(runner):
     assert 'Usage: happy' in result.output
 
 
-def test_up(happy, runner):
+@isolated
+def test_up(runner, happy):
     """Running up should exit cleanly."""
-    with runner.isolated_filesystem():
-        result = runner.invoke(cli, ['up', '--tarball-url=example.com'])
+    result = runner.invoke(cli, ['up', '--tarball-url=example.com'])
 
     assert result.exit_code == 0
 
 
-def test_up_auth_token(happy, runner):
+@isolated
+def test_up_auth_token(runner, happy):
     """Running up should pass the --auth-token option to Happy."""
-    with runner.isolated_filesystem():
-        runner.invoke(cli, [
-            'up',
-            '--tarball-url=example.com',
-            '--auth-token=12345',
-        ])
+    runner.invoke(cli, [
+        'up',
+        '--tarball-url=example.com',
+        '--auth-token=12345',
+    ])
 
     args_, kwargs = happy.call_args
 
     assert kwargs['auth_token'] == '12345'
 
 
-def test_up_tarball_url(happy, runner):
+@isolated
+def test_up_tarball_url(runner, happy):
     """Running up should pass the --tarball-url option to Happy.create."""
-    with runner.isolated_filesystem():
-        runner.invoke(cli, ['up', '--tarball-url=example.com'])
+    runner.invoke(cli, ['up', '--tarball-url=example.com'])
 
     args_, kwargs = happy().create.call_args
 
     assert kwargs['tarball_url'] == 'example.com'
 
 
-def test_up_tarball_url_app_json(happy, runner):
+@isolated
+def test_up_tarball_url_app_json(runner, happy):
     """Running up should infer the tarball URL from app.json."""
-    with runner.isolated_filesystem():
-        with open('app.json', 'w') as f:
-            f.write('{"repository": "https://github.com/butt/man"}')
+    with open('app.json', 'w') as f:
+        f.write('{"repository": "https://github.com/butt/man"}')
 
-        runner.invoke(cli, ['up'])
+    runner.invoke(cli, ['up'])
 
     args_, kwargs = happy().create.call_args
 
@@ -87,26 +98,26 @@ def test_up_tarball_url_app_json(happy, runner):
         'https://github.com/butt/man/tarball/master/'
 
 
-def test_up_no_tarball_url(happy, runner):
+@isolated
+def test_up_no_tarball_url(runner, happy):
     """Running up should fail if it can't infer the tarball URL."""
-    with runner.isolated_filesystem():
-        result = runner.invoke(cli, ['up'])
+    result = runner.invoke(cli, ['up'])
 
     assert result.exit_code == 1
     assert 'no tarball' in result.output.lower()
 
 
-def test_up_env(happy, runner):
+@isolated
+def test_up_env(runner, happy):
     """Running up --env should pass environment overrides."""
-    with runner.isolated_filesystem():
-        runner.invoke(cli, [
-            'up',
-            '--env',
-            'FART=test',
-            '--env',
-            'BUTT=wow',
-            '--tarball-url=example.com',
-        ])
+    runner.invoke(cli, [
+        'up',
+        '--env',
+        'FART=test',
+        '--env',
+        'BUTT=wow',
+        '--tarball-url=example.com',
+    ])
 
     args_, kwargs = happy().create.call_args
 
@@ -116,25 +127,26 @@ def test_up_env(happy, runner):
     }
 
 
-def test_up_writes_app_name(happy, runner):
+@isolated
+def test_up_writes_app_name(runner, happy):
     """Running up should write the app name to .happy."""
-    with runner.isolated_filesystem():
-        runner.invoke(cli, ['up', '--tarball-url=example.com'])
+    runner.invoke(cli, ['up', '--tarball-url=example.com'])
 
-        with open('.happy') as f:
-            app_name = f.read()
+    with open('.happy') as f:
+        app_name = f.read()
 
     assert app_name == 'butt-man-123'
 
 
-def test_up_waits_for_build(happy, runner):
+@isolated
+def test_up_waits_for_build(runner, happy):
     """The up command should wait for builds to complete."""
 
 
-def test_up_prints_info(happy, runner):
+@isolated
+def test_up_prints_info(runner, happy):
     """Running up should print status info."""
-    with runner.isolated_filesystem():
-        result = runner.invoke(cli, ['up', '--tarball-url=example.com'])
+    result = runner.invoke(cli, ['up', '--tarball-url=example.com'])
 
     assert result.output == (
         "Creating app... butt-man-123\n"
@@ -143,62 +155,62 @@ def test_up_prints_info(happy, runner):
     )
 
 
-def test_down(happy, runner):
+@isolated
+def test_down(runner, happy):
     """Running down should delete the app."""
-    with runner.isolated_filesystem():
-        with open('.happy', 'w') as f:
-            f.write('butt-man-123')
+    with open('.happy', 'w') as f:
+        f.write('butt-man-123')
 
-        result = runner.invoke(cli, ['down'])
+    result = runner.invoke(cli, ['down'])
 
     happy().delete.assert_called_with(app_name='butt-man-123')
     assert result.exit_code == 0
 
 
-def test_down_auth_token(happy, runner):
+@isolated
+def test_down_auth_token(runner, happy):
     """Running down should pass the --auth-token option to Happy."""
-    with runner.isolated_filesystem():
-        with open('.happy', 'w') as f:
-            f.write('butt-man-123')
+    with open('.happy', 'w') as f:
+        f.write('butt-man-123')
 
-        runner.invoke(cli, [
-            'down',
-            '--auth-token=12345',
-        ])
+    runner.invoke(cli, [
+        'down',
+        '--auth-token=12345',
+    ])
 
     args_, kwargs = happy.call_args
 
     assert kwargs['auth_token'] == '12345'
 
 
-def test_down_deletes_app_name_file(happy, runner):
+@isolated
+def test_down_deletes_app_name_file(runner, happy):
     """Running down should delete the .happy file."""
-    with runner.isolated_filesystem():
-        with open('.happy', 'w') as f:
-            f.write('butt-man-123')
+    with open('.happy', 'w') as f:
+        f.write('butt-man-123')
 
-        runner.invoke(cli, ['down'])
+    runner.invoke(cli, ['down'])
 
-        with pytest.raises(IOError):
-            open('.happy', 'r')
+    with pytest.raises(IOError):
+        open('.happy', 'r')
 
 
-def test_down_no_app(happy, runner):
+@isolated
+def test_down_no_app(runner, happy):
     """With no app to delete, down should fail."""
-    with runner.isolated_filesystem():
-        result = runner.invoke(cli, ['down'])
+    result = runner.invoke(cli, ['down'])
 
     assert happy().delete.called is False
     assert result.exit_code == 1
 
 
-def test_down_prints_info(happy, runner):
+@isolated
+def test_down_prints_info(runner, happy):
     """Running down should print status info."""
-    with runner.isolated_filesystem():
-        with open('.happy', 'w') as f:
-            f.write('butt-man-123')
+    with open('.happy', 'w') as f:
+        f.write('butt-man-123')
 
-        result = runner.invoke(cli, ['down'])
+    result = runner.invoke(cli, ['down'])
 
     assert result.output == (
         "Destroying app butt-man-123... done\n"

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -196,6 +196,16 @@ def test_down(runner, happy):
 
 
 @isolated
+def test_down_app_name(runner, happy):
+    """Running down should pass the first param as the app name."""
+    runner.invoke(cli, ['down', 'app-name-123'])
+
+    args_, kwargs = happy().delete.call_args
+
+    assert kwargs['app_name'] == 'app-name-123'
+
+
+@isolated
 def test_down_auth_token(runner, happy):
     """Running down should pass the --auth-token option to Happy."""
     with open('.happy', 'w') as f:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -145,6 +145,9 @@ def test_up_writes_app_name(runner, happy):
 @isolated
 def test_up_waits_for_build(runner, happy):
     """The up command should wait for builds to complete."""
+    runner.invoke(cli, ['up'])
+
+    assert happy().wait.called
 
 
 @isolated

--- a/tests/test_happy.py
+++ b/tests/test_happy.py
@@ -40,6 +40,18 @@ def test_create(heroku, happy):
     happy.create(tarball_url='tarball-url')
 
     heroku().create_build.assert_called_with(
+        app_name=None,
+        env=None,
+        tarball_url='tarball-url',
+    )
+
+
+def test_create_app_name(heroku, happy):
+    """Should pass app_name to Heroku.create_build."""
+    happy.create(tarball_url='tarball-url', app_name='app-name-123')
+
+    heroku().create_build.assert_called_with(
+        app_name='app-name-123',
         env=None,
         tarball_url='tarball-url',
     )
@@ -52,6 +64,7 @@ def test_create_env(heroku, happy):
     heroku().create_build.assert_called_with(
         tarball_url='tarball-url',
         env={'TEST': 'env'},
+        app_name=None,
     )
 
 

--- a/tests/test_heroku.py
+++ b/tests/test_heroku.py
@@ -126,7 +126,7 @@ def test_heroku_create_build(api_request):
 
 @mock.patch.object(Heroku, 'api_request')
 def test_heroku_create_build_env(api_request):
-    """Heroku.create_build should send a POST to /app-setups."""
+    """Heroku.create_build should send env overrides."""
     heroku = Heroku()
 
     result = heroku.create_build('tarball-url', env={'HELLO': 'world'})
@@ -137,6 +137,23 @@ def test_heroku_create_build_env(api_request):
         data={
             'source_blob': {'url': 'tarball-url'},
             'overrides': {'env': {'HELLO': 'world'}},
+        },
+    )
+
+
+@mock.patch.object(Heroku, 'api_request')
+def test_heroku_create_build_app_name(api_request):
+    """Heroku.create_build should send the app name."""
+    heroku = Heroku()
+
+    result = heroku.create_build('tarball-url', app_name='app-name-123')
+
+    api_request.assert_called_with(
+        'POST',
+        '/app-setups',
+        data={
+            'source_blob': {'url': 'tarball-url'},
+            'app': {'name': 'app-name-123'},
         },
     )
 

--- a/tox.ini
+++ b/tox.ini
@@ -13,3 +13,4 @@ deps =
     pytest-cov
     pytest-pep8
     mock
+    decorator


### PR DESCRIPTION
This adds an `app_name` parameter to `happy up` and `happy down`, adds a prompt to `happy down`, and deprecates the implicit version of `happy down`.

It also cleans up the tests and stuff a bit.

Closes #7.
